### PR TITLE
Enable compatibility of sparse MOE training under DeepSpeed ZeRO3

### DIFF
--- a/examples/sft/ds_config_zero3.json
+++ b/examples/sft/ds_config_zero3.json
@@ -43,7 +43,7 @@
         "contiguous_gradients": true,
         "sub_group_size": 1e9,
         "reduce_bucket_size": "auto",
-        "stage3_prefetch_bucket_size": "auto",
+        "stage3_prefetch_bucket_size": "0",
         "stage3_param_persistence_threshold": "auto",
         "stage3_max_live_parameters": 1e9,
         "stage3_max_reuse_distance": 1e9,


### PR DESCRIPTION
According to https://github.com/microsoft/DeepSpeed/pull/4966, ZeRO3 in DeepSpeed does not work with MoE models because the order of executing modules can change at every forward/backward pass and a new API is implemented to stop breaking down a module for parameter fetching. Similar case occurs when finetuning Qwen1.5-MoE-A2.7B using ZeRO3 optimization(https://github.com/QwenLM/Qwen1.5/issues/275).



This PR use the api above to make sparse MoE layer compatible with Zero3.