### PR TITLE
Fix link issues, etc

### DIFF
--- a/docs/source/framework/qwen_agent.rst
+++ b/docs/source/framework/qwen_agent.rst
@@ -39,7 +39,7 @@ tools and quickly develop an agent that uses tools.
        'model': 'qwen-max',
        'model_server': 'dashscope',
        # 'api_key': 'YOUR_DASHSCOPE_API_KEY',
-       # It will use the `DASHSCOPE_API_KEY' environment variable if 'api_key' is not set here.
+       # It will use the 'DASHSCOPE_API_KEY' environment variable if 'api_key' is not set here.
 
        # Use your own model service compatible with OpenAI API:
        # 'model': 'Qwen/Qwen2-72B-Instruct',

--- a/docs/source/training/SFT/example.rst
+++ b/docs/source/training/SFT/example.rst
@@ -5,7 +5,7 @@ Here we provide a very simple script for supervised finetuning, which is revised
 script in `Fastchat <https://github.com/lm-sys/FastChat>`__. The
 script is used to finetune Qwen with Hugging Face Trainer. You can check
 the script
-`here <https://github.com/QwenLM/Qwen2/blob/main/finetune.py>`__. This
+`here <https://github.com/QwenLM/Qwen2/blob/main/examples/sft/finetune.py>`__. This
 script for supervised finetuning (SFT) has the following features:
 
 -  Support single-GPU and multi-GPU training;


### PR DESCRIPTION
The link address in the document "example.rst" is incorrect and has been corrected in PR.Affects the reading of the page "https://qwen.readthedocs.io/zh-cn/latest/training/SFT/example.html"
And there is a punctuation error in "qwen_agent.rst"