### PR TITLE
Fix model device placement in README code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ model = AutoModelForCausalLM.from_pretrained(
     torch_dtype="auto",
     device_map="auto"
 )
+model = model.to(device=device)
+
 tokenizer = AutoTokenizer.from_pretrained(model_name)
 
 prompt = "Give me a short introduction to large language model."


### PR DESCRIPTION
updates the README code snippet to explicitly move the model to the CUDA device. This change improves user-friendliness by reducing potential confusion and performance issues, especially for users unfamiliar with PyTorch or CUDA device management. Without this fix, users executing the original code snippet may experience significantly slower inference performance:)

